### PR TITLE
update version for dgraph-io/badger/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,10 @@ go 1.15
 replace github.com/hyperledger-labs/mirbft => ../../github.com/matejpavlovic/mirbft
 
 require (
+	github.com/DataDog/zstd v1.4.1 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/dgraph-io/badger/v2 v2.2007.2
+	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger/v2 v2.2007.2 h1:EjjK0KqwaFMlPin1ajhP943VPENHJdEz1KLIegjaI3k=
 github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
+github.com/dgraph-io/badger/v2 v2.2007.4 h1:TRWBQg8UrlUhaFdco01nO2uXwzKS7zd+HVdwV/GHc4o=
+github.com/dgraph-io/badger/v2 v2.2007.4/go.mod h1:vSw/ax2qojzbN6eXHIx6KPKtCSHJN/Uz0X0VPruTIhk=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
@@ -37,6 +39,8 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -45,6 +49,8 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.12.3 h1:G5AfA94pHPysR56qqrkO2pxEexdDzrpFJ6yt/VqWxVU=
+github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
Hi, playing around with this, I had problems on OSX with the version of badger in the go.mod file:  Specifically, it was issues with acquiring a directory lock on Darwin, here is an excerpt of the stack trace:

```
/usr/local/Cellar/go/1.17/libexec/src/runtime/sys_darwin.go:22 +0x3b fp=0xc0000b6bf8 sp=0xc0000b6bd8 pc=0x40631bb
syscall.syscall(0xc0000b6c60, 0x0, 0xc000000000, 0x23)
	<autogenerated>:1 +0x26 fp=0xc0000b6c40 sp=0xc0000b6bf8 pc=0x4068fc6
golang.org/x/sys/unix.Flock(0xc0000b2ae0, 0x1e)
	/Users/jamie/Code/go/pkg/mod/golang.org/x/sys@v0.0.0-20200821140526-fda516888d29/unix/zsyscall_darwin_amd64.go:1150 +0x38 fp=0xc0000b6c70 sp=0xc0000b6c40 pc=0x43ae2f8
github.com/dgraph-io/badger/v2.acquireDirectoryLock({0xc0000b2ae0, 0x1e}, {0x469449b, 0x1e}, 0x0)
	/Users/jamie/Code/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.2007.2/dir_unix.go:62 +0x125 fp=0xc0000b6d30 sp=0xc0000b6c70 pc=0x43db1e5
github.com/dgraph-io/badger/v2.Open({{0xc0000b2ae0, 0x1e}, {0xc0000b2ae0, 0x1e}, 0x0, 0x2, 0x2, 0x1, 0x0, 0x1, ...})
	/Users/jamie/Code/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.2007.2/db.go:255 +0x35e fp=0xc0000b7470 sp=0xc0000b6d30 pc=0x43d065e
github.com/hyperledger-labs/mirbft/pkg/reqstore.Open({0xc0000b2ae0, 0x47400a0})
	/Users/jamie/Code/go/pkg/mod/github.com/hyperledger-labs/mirbft@v0.0.0-20210416025957-dacbccccdb69/pkg/reqstore/reqstore.go:40 +0x245 
```

I reproduced the problem locally in a small test, where I did nothing other than try to open a badger.DB at v2.2007.2, and it exhibited the same error.

I solved the problem locally by upgrading `github.com/dgraph-io/badger/v2 v2.2007.2` to `github.com/dgraph-io/badger/v2 v2.2007.4`