### PR TITLE
Redefine Net module, adding message reception

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,7 +17,7 @@ type NodeConfig struct {
 	// Logger provides the logging functions.
 	Logger logger.Logger
 
-	// BufferSize is the total size of messages which can be held by the state
+	// BufferSize is the total size of messages which can be held by the protocol state
 	// machine, pending application, for each node. This is necessary because
 	// there may be dependencies between messages (for instance, until a checkpoint
 	// result is computed, watermarks cannot advance). This should be set

--- a/pkg/deploytest/faketransport.go
+++ b/pkg/deploytest/faketransport.go
@@ -29,6 +29,13 @@ func (fl *FakeLink) Send(dest uint64, msg *messagepb.Message) {
 	fl.FakeTransport.Send(fl.Source, dest, msg)
 }
 
+func (fl *FakeLink) Receive(stopChan <-chan struct{}) (source uint64, msg *messagepb.Message, err error) {
+	// FakeLink does not support receiving messages, those need to be received by the user code directly
+	// From FakeTransport (using RecvC) and injected manually in the Node (using Node.Step).
+	<-stopChan
+	return 0, nil, nil
+}
+
 type FakeTransport struct {
 	// Buffers is source x dest
 	Buffers   [][]chan *messagepb.Message

--- a/pkg/modules/net.go
+++ b/pkg/modules/net.go
@@ -8,8 +8,28 @@ package modules
 
 import "github.com/hyperledger-labs/mirbft/pkg/pb/messagepb"
 
-// The Net module provides a simple abstract interface for sending messages to other nodes.
-// TODO: Write comments.
+// The Net module provides a simple abstract interface for sending messages to and receiving messages from other nodes.
+// It abstracts away all network-related data and only deals with abstract numeric node IDs of senders and receivers
+// at the interface. The messages returned from the Receive() must be (the library assumes them to be) authenticated.
+// TODO: Deal explicitly with membership somewhere (not necessarily here).
+// Note that the Net module's Receive() method is (currently? TODO)
+// one of two ways of injecting messages in the Node.
+// Alternatively, the Node.Step() method can be used directly to inject incoming messages.
+// The user might choose to use the latter option, using the Net module only for sending.
+// In such a case, the implementation of the Receive() method of the used Net module must simply block
+// until interrupted by the passed channel (see documentation of Receive()).
 type Net interface {
+
+	// Send sends msg to the node with ID dest.
+	// Concurrent calls to Send are not (yet? TODO) supported.
 	Send(dest uint64, msg *messagepb.Message)
+
+	// Receive blocks until a message is received by the Net module and returns
+	// the numeric ID of the sender and the message itself.
+	// If an error occurs, Receive() returns (0, nil, non-nil error).
+	// Receive() can be interrupted by closing stopChan, in which case it returns immediately.
+	// In this case, it may either return a sender ID and a non-nil message
+	// (if a message arrived concurrently with closing stopChan),
+	// or (more probably) the tuple (0, nil, nil).
+	Receive(stopChan <-chan struct{}) (source uint64, msg *messagepb.Message, err error)
 }


### PR DESCRIPTION
The interface of the Net module now contains also a Receive() function,
such that all networking can be encapsulated inside that module.
The option of injecting messages manually (through Node.Step()) still exists
and is an alternative to using the Net module's interface.
