### PR TITLE
Use proper epoch numbers with checkpoint messages

### DIFF
--- a/samples/chat-demo/main.go
+++ b/samples/chat-demo/main.go
@@ -144,7 +144,6 @@ func main() {
 
 	// Instantiate the ISS protocol module with default configuration.
 	issConfig := iss.DefaultConfig(nodeIds)
-	issConfig.SegmentLength = 3 // TODO: DEBUG: Remove this line.
 	issProtocol, err := iss.New(args.OwnId, issConfig, logger)
 	if err != nil {
 		panic(fmt.Errorf("could not instantiate ISS protocol module: %w", err))


### PR DESCRIPTION
The epoch number of a checkpint now always corresponds to the epoch
the associated sequence number belongs to.
At epoch transition, rathen than having an epoch "end" with a checkpoint,
the next epoch "starts" with a checkpoint, and thus the checkpoint
is associated with the new epoch rather than with the old one.
This also makes more sense with respect to the associated sequence number.

Signed-off-by: Matej Pavlovic <matopavlovic@gmail.com>